### PR TITLE
[1.7.10] Fix More Planets compatibility issue with Kepler 22b

### DIFF
--- a/src/main/java/com/mjr/extraplanets/planets/ExtraPlanets_Planets.java
+++ b/src/main/java/com/mjr/extraplanets/planets/ExtraPlanets_Planets.java
@@ -180,7 +180,10 @@ public class ExtraPlanets_Planets {
 		}
 		if (Config.kepler22b && Config.keplerSolarSystems) {
 			kepler22b = new Planet("kepler22b").setParentSolarSystem(ExtraPlanets_SolarSystems.kepler22);
-			kepler22b.setTierRequired(10);
+			if (Config.morePlanetsCompatibilityAdv)
+				kepler22b.setTierRequired(7);
+			else
+				kepler22b.setTierRequired(10);
 			kepler22b.setRingColorRGB(0.1F, 0.9F, 0.6F);
 			kepler22b.setPhaseShift(1.45F);
 			kepler22b.setRelativeDistanceFromCenter(new CelestialBody.ScalableDistance(0.5F, 0.5F));


### PR DESCRIPTION
Fix Kepler 22b being inaccessible with More Planets compatibility enabled by changing the rocket tier required. If you want to change it to tier 8 instead of 7 that's fine.