### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/com/mjr/extraplanets/handlers/AchievementEventHandler.java
+++ b/src/main/java/com/mjr/extraplanets/handlers/AchievementEventHandler.java
@@ -30,6 +30,9 @@ import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 public class AchievementEventHandler {
 	@SubscribeEvent
 	public void onCrafting(ItemCraftedEvent event) {
+		if (event.crafting == null) {
+			return;
+		}
 		if (event.crafting.getItem() instanceof BasicPickaxe) {
 			if (event.crafting.getItem() == ExtraPlanets_Tools.carbonPickaxe) {
 


### PR DESCRIPTION
Not sure what caused this. Some sort of issue with AE2 I guess. Log:

```
[20:13:05] [Server thread/ERROR]: Exception caught during firing event cpw.mods.fml.common.gameevent.PlayerEvent$ItemCraftedEvent@4f73f66a:
java.lang.NullPointerException
	at com.mjr.extraplanets.handlers.AchievementEventHandler.onCrafting(AchievementEventHandler.java:33) ~[AchievementEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_376_AchievementEventHandler_onCrafting_ItemCraftedEvent.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:1.7.10-1614.kmecpp]
	at appeng.util.Platform.findMatchingRecipe(Platform.java:589) [Platform.class:?]
	at appeng.container.slot.SlotCraftingTerm.craftItem(SlotCraftingTerm.java:150) [SlotCraftingTerm.class:?]
	at appeng.container.slot.SlotCraftingTerm.doClick(SlotCraftingTerm.java:121) [SlotCraftingTerm.class:?]
	at appeng.container.AEBaseContainer.doAction(AEBaseContainer.java:608) [AEBaseContainer.class:?]
	at appeng.core.sync.packets.PacketInventoryAction.serverPacketData(PacketInventoryAction.java:130) [PacketInventoryAction.class:?]
	at appeng.core.sync.network.AppEngServerPacketHandler.onPacketData(AppEngServerPacketHandler.java:39) [AppEngServerPacketHandler.class:?]
	at appeng.core.sync.network.NetworkHandler.serverPacket(NetworkHandler.java:85) [NetworkHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_351_NetworkHandler_serverPacket_ServerCustomPacketEvent.invoke(.dynamic) [?:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) [ASMEventHandler.class:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) [EventBus.class:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.network.FMLEventChannel.fireRead(FMLEventChannel.java:103) [FMLEventChannel.class:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:30) [NetworkEventFiringHandler.class:1.7.10-1614.kmecpp]
	at cpw.mods.fml.common.network.NetworkEventFiringHandler.channelRead0(NetworkEventFiringHandler.java:18) [NetworkEventFiringHandler.class:1.7.10-1614.kmecpp]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) [SimpleChannelInboundHandler.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [DefaultChannelPipeline.class:?]
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) [EmbeddedChannel.class:?]
	at cpw.mods.fml.common.network.internal.FMLProxyPacket.func_148833_a(FMLProxyPacket.java:77) [FMLProxyPacket.class:1.7.10-1614.kmecpp]
	at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:245) [ej.class:?]
	at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:181) [nc.class:?]
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:1112) [MinecraftServer.class:?]
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:432) [lt.class:?]
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:921) [MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:738) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
```